### PR TITLE
Fix poetry path in github actions

### DIFF
--- a/.github/workflows/publish-screenshots.yml
+++ b/.github/workflows/publish-screenshots.yml
@@ -27,14 +27,14 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'poetry'
+          cache-dependency-path: 'poetry.lock'
 
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v3
+        uses: snok/install-poetry@v1
         with:
-          poetry-version: '1.8.3'
-
-      - name: Ensure Poetry is in PATH
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+          version: 1.8.3
+          virtualenvs-create: true
+          virtualenvs-in-project: true
 
       - name: Install dependencies (with dev)
         run: |


### PR DESCRIPTION
Replace Poetry installation action in `publish-screenshots.yml` to resolve "poetry not found" errors.

The previous Poetry setup was intermittently failing to add `poetry` to the PATH, leading to "Unable to locate executable file: poetry" errors in the GitHub Action. This change uses a more robust action (`snok/install-poetry@v1`) which handles PATH setup automatically and ensures Poetry is consistently available.

---
<a href="https://cursor.com/background-agent?bcId=bc-f46c1ba7-355a-4ca3-a7af-dcdaa18cf7bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f46c1ba7-355a-4ca3-a7af-dcdaa18cf7bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

